### PR TITLE
7 feature 2 implement start of turn

### DIFF
--- a/src/main/java/entities/decks/PlayerDeck.java
+++ b/src/main/java/entities/decks/PlayerDeck.java
@@ -29,6 +29,10 @@ public class PlayerDeck implements Deck {
 
     @Override
     public Card draw() {
-        return cards.remove(getDeckSize() - 1);
+        if (getDeckSize() > 0) {
+            return cards.remove(getDeckSize() - 1);
+        } else {
+            return null;
+        }
     }
 }

--- a/src/main/java/use_cases/turn_start_use_case/CreatureStatsUpdateModel.java
+++ b/src/main/java/use_cases/turn_start_use_case/CreatureStatsUpdateModel.java
@@ -2,10 +2,9 @@ package use_cases.turn_start_use_case;
 
 import java.util.ArrayList;
 import java.util.List;
-public class TurnStartResponseModel {
 
-    private List<Integer> handIds1;
-    private List<Integer> handIds2;
+public class CreatureStatsUpdateModel {
+
     private List<Integer> creatureIds1;
     private List<Integer> creatureIds2;
     private List<Integer> hitPoints1;
@@ -13,39 +12,15 @@ public class TurnStartResponseModel {
     private List<Integer> attacks1;
     private List<Integer> attacks2;
 
-
-    public TurnStartResponseModel(List<Integer> handIds1) {
-        this.handIds1 = handIds1;
-    }
-
-    public TurnStartResponseModel(List<Integer> handIds1, List<Integer> handIds2,
-                                  List<Integer> creatureIds1, List<Integer> creatureIds2,
-                                  List<Integer> hitPoints1, List<Integer> hitPoints2,
-                                  List<Integer> attacks1, List<Integer> attacks2) {
-        this.handIds1 = handIds1;
-        this.handIds2 = handIds2;
+    public CreatureStatsUpdateModel(List<Integer> creatureIds1, List<Integer> creatureIds2,
+                                    List<Integer> hitPoints1, List<Integer> hitPoints2,
+                                    List<Integer> attacks1, List<Integer> attacks2) {
         this.creatureIds1 = creatureIds1;
         this.creatureIds2 = creatureIds2;
         this.hitPoints1 = hitPoints1;
         this.hitPoints2 = hitPoints2;
         this.attacks1 = attacks1;
         this.attacks2 = attacks2;
-    }
-
-    public List<Integer> getHandIds1() {
-        return handIds1;
-    }
-
-    public void setHandIds1(List<Integer> handIds1) {
-        this.handIds1 = handIds1;
-    }
-
-    public List<Integer> getHandIds2() {
-        return handIds2;
-    }
-
-    public void setHandIds2(List<Integer> handIds2) {
-        this.handIds2 = handIds2;
     }
 
     public List<Integer> getCreatureIds1() {

--- a/src/main/java/use_cases/turn_start_use_case/DrawCardOutputModel.java
+++ b/src/main/java/use_cases/turn_start_use_case/DrawCardOutputModel.java
@@ -1,0 +1,51 @@
+package use_cases.turn_start_use_case;
+
+import java.util.List;
+
+public class DrawCardOutputModel {
+
+    private List<Integer> newCardIds;
+    private List<String> newCardNames;
+    private List<Integer> burntCardIds;
+    private List<String> burntCardNames;
+
+    public DrawCardOutputModel(List<Integer> newCardIds, List<String> newCardNames,
+                               List<Integer> burntCardIds, List<String> burntCardNames) {
+        this.newCardIds = newCardIds;
+        this.newCardNames = newCardNames;
+        this.burntCardIds = burntCardIds;
+        this.burntCardNames = burntCardNames;
+    }
+
+    public List<Integer> getNewCardIds() {
+        return newCardIds;
+    }
+
+    public void setNewCardIds(List<Integer> newCardIds) {
+        this.newCardIds = newCardIds;
+    }
+
+    public List<String> getNewCardNames() {
+        return newCardNames;
+    }
+
+    public void setNewCardNames(List<String> newCardNames) {
+        this.newCardNames = newCardNames;
+    }
+
+    public List<Integer> getBurntCardIds() {
+        return burntCardIds;
+    }
+
+    public void setBurntCardIds(List<Integer> burntCardIds) {
+        this.burntCardIds = burntCardIds;
+    }
+
+    public List<String> getBurntCardNames() {
+        return burntCardNames;
+    }
+
+    public void setBurntCardNames(List<String> burntCardNames) {
+        this.burntCardNames = burntCardNames;
+    }
+}

--- a/src/main/java/use_cases/turn_start_use_case/TriggerEffectUpdateModel.java
+++ b/src/main/java/use_cases/turn_start_use_case/TriggerEffectUpdateModel.java
@@ -1,0 +1,30 @@
+package use_cases.turn_start_use_case;
+
+import java.util.List;
+
+public class TriggerEffectUpdateModel {
+
+    private List<Integer> finalHandIds;
+    private CreatureStatsUpdateModel allCreatureStats;
+
+    public TriggerEffectUpdateModel(List<Integer> finalHandIds, CreatureStatsUpdateModel allCreatureStats) {
+        this.finalHandIds = finalHandIds;
+        this.allCreatureStats = allCreatureStats;
+    }
+
+    public List<Integer> getFinalHandIds() {
+        return finalHandIds;
+    }
+
+    public void setFinalHandIds(List<Integer> finalHandIds) {
+        this.finalHandIds = finalHandIds;
+    }
+
+    public CreatureStatsUpdateModel getAllCreatureStats() {
+        return allCreatureStats;
+    }
+
+    public void setAllCreatureStats(CreatureStatsUpdateModel allCreatureStats) {
+        this.allCreatureStats = allCreatureStats;
+    }
+}

--- a/src/main/java/use_cases/turn_start_use_case/TurnStartInputBoundary.java
+++ b/src/main/java/use_cases/turn_start_use_case/TurnStartInputBoundary.java
@@ -1,9 +1,43 @@
 package use_cases.turn_start_use_case;
 
+/**
+ * TurnStartInputBoundary provides the interface for handling the start-of-turn
+ * logic. The start-of-turn events are separated into 3 parts and handled
+ * individually.
+ * - The player taking their turn draws cards, which requires an update to their
+ * hand cards.
+ * - The player's creatures should be cleared of their HP and Attack buffs, and
+ * this should have its own output data.
+ * - The start of turn effects are triggered, if any. This requires a combination
+ * of card and stats updates.
+ */
 public interface TurnStartInputBoundary {
-    TurnStartResponseModel drawCards();
 
-    TurnStartResponseModel clearTemporaryEffects();
+    /**
+     * Draws cards for the current player: 2 cards from their play deck and 2
+     * more cards from their Essence deck (4 in total).
+     *
+     * @return a DrawCardOutputModel, showing which cards are successfully added
+     * to the hand and which are discarded due to hand being full.
+     */
+    DrawCardOutputModel drawCards();
 
-    TurnStartResponseModel triggerTurnStartEffects();
+    /**
+     * Clear the HP and Attack buffs on each creature of the current player.
+     *
+     * @return a CreatureStatsUpdateModel, containing creature ids and stats
+     * like hit-points and attacks.
+     */
+    CreatureStatsUpdateModel clearBuffs();
+
+    /**
+     * Trigger the start-of-turn effects in the active structure of the current
+     * player, if it does exist.
+     * This method returns many values because the effects have a variety of
+     * targets, so outcomes also vary.
+     *
+     * @return a TriggerEffectUpdateModel, a combination of a list of hand card
+     * ids and a CreatureStatsUpdateModel.
+     */
+    TriggerEffectUpdateModel triggerTurnStartEffects();
 }

--- a/src/main/java/use_cases/turn_start_use_case/TurnStartInputBoundary.java
+++ b/src/main/java/use_cases/turn_start_use_case/TurnStartInputBoundary.java
@@ -1,0 +1,9 @@
+package use_cases.turn_start_use_case;
+
+public interface TurnStartInputBoundary {
+    TurnStartResponseModel drawCards();
+
+    TurnStartResponseModel clearTemporaryEffects();
+
+    TurnStartResponseModel triggerTurnStartEffects();
+}

--- a/src/main/java/use_cases/turn_start_use_case/TurnStartInteractor.java
+++ b/src/main/java/use_cases/turn_start_use_case/TurnStartInteractor.java
@@ -159,7 +159,6 @@ public class TurnStartInteractor implements TurnStartInputBoundary {
 
         TriggerEffectUpdateModel outputData = new TriggerEffectUpdateModel(handIds, getCreatureStatsModel());
 
-
         return turnStartPresenter.showEffectUpdates(outputData);
     }
 

--- a/src/main/java/use_cases/turn_start_use_case/TurnStartInteractor.java
+++ b/src/main/java/use_cases/turn_start_use_case/TurnStartInteractor.java
@@ -66,7 +66,8 @@ public class TurnStartInteractor implements TurnStartInputBoundary {
                     burntIds.add(card.getId());
                     burntNames.add(card.getName());
                 }
-
+            } else {
+                 break;
             }
         }
         for (int i = 0; i < 2; i++) {

--- a/src/main/java/use_cases/turn_start_use_case/TurnStartInteractor.java
+++ b/src/main/java/use_cases/turn_start_use_case/TurnStartInteractor.java
@@ -82,7 +82,8 @@ public class TurnStartInteractor implements TurnStartInputBoundary {
 
         }
 
-        DrawCardOutputModel output = new DrawCardOutputModel(keptIds,keptNames,burntIds,burntNames);
+        DrawCardOutputModel output = new DrawCardOutputModel(keptIds, keptNames, burntIds, burntNames);
+        
         return turnStartPresenter.showDrawResult(output);
     }
 

--- a/src/main/java/use_cases/turn_start_use_case/TurnStartInteractor.java
+++ b/src/main/java/use_cases/turn_start_use_case/TurnStartInteractor.java
@@ -1,0 +1,31 @@
+package use_cases.turn_start_use_case;
+
+import entities.GameState;
+
+public class TurnStartInteractor implements TurnStartInputBoundary {
+
+    final GameState gameState;
+
+    final TurnStartOutputBoundary turnStartPresenter;
+
+    public TurnStartInteractor(GameState gameState, TurnStartOutputBoundary turnStartPresenter) {
+        this.gameState = gameState;
+        this.turnStartPresenter = turnStartPresenter;
+    }
+
+
+    @Override
+    public TurnStartResponseModel drawCards() {
+        return null;
+    }
+
+    @Override
+    public TurnStartResponseModel clearTemporaryEffects() {
+        return null;
+    }
+
+    @Override
+    public TurnStartResponseModel triggerTurnStartEffects() {
+        return null;
+    }
+}

--- a/src/main/java/use_cases/turn_start_use_case/TurnStartInteractor.java
+++ b/src/main/java/use_cases/turn_start_use_case/TurnStartInteractor.java
@@ -1,6 +1,15 @@
 package use_cases.turn_start_use_case;
 
 import entities.GameState;
+import entities.Player;
+import entities.cards.Card;
+import entities.cards.CreatureCard;
+import entities.decks.EssenceDeck;
+import entities.decks.PlayerDeck;
+
+import java.util.ArrayList;
+import java.util.List;
+
 
 public class TurnStartInteractor implements TurnStartInputBoundary {
 
@@ -16,12 +25,54 @@ public class TurnStartInteractor implements TurnStartInputBoundary {
 
     @Override
     public TurnStartResponseModel drawCards() {
-        return null;
+
+        //Getting the player deck from the current player
+        Player player = gameState.getCurrentPlayer();
+        PlayerDeck deck = player.getPlayerDeck();
+
+        //Getting the essence deck from the current player
+        EssenceDeck edeck = player.getEssenceDeck();
+
+        //Drawing twice from the player deck then from the essence deck
+        for(int i = 0; i < 2; i++){
+            player.addCard(deck.draw());
+            player.addCard(edeck.draw());
+
+        }
+
+        //Getting a list of all cards in the player hands and returning it
+        List<Card> hand = player.getHand();
+        List<Integer> handIds = new ArrayList<>();
+        for (int i = 0; i < hand.size(); i++){
+            handIds.add(hand.get(i).getId());
+        }
+
+        TurnStartResponseModel output = new TurnStartResponseModel(handIds);
+        return turnStartPresenter.updateScreen(output);
     }
 
     @Override
     public TurnStartResponseModel clearTemporaryEffects() {
-        return null;
+
+        Player player = gameState.getCurrentPlayer();
+        List<CreatureCard> creatures = player.getCreatures();
+        List<Integer> creatureIds = new ArrayList<>();
+        List<Integer> hitPoints = new ArrayList<>();
+        List<Integer> attacks = new ArrayList<>();
+        for (int i = 0; i < creatures.size(); i++){
+            creatures.get(i).clearDamageBuff();
+            creatures.get(i).clearHealthBuff();
+            creatures.get(i).clearStun();
+            creatureIds.add(creatures.get(i).getId());
+            hitPoints.add(creatures.get(i).getTotalHitPoints());
+            attacks.add(creatures.get(i).getTotalAttackDamage());
+        }
+
+        TurnStartResponseModel output = new TurnStartResponseModel(new ArrayList<>(), new ArrayList<>(),
+                creatureIds, new ArrayList<>(),
+                hitPoints,new ArrayList<>(),
+                attacks, new ArrayList<>());
+        return turnStartPresenter.updateScreen(output);
     }
 
     @Override

--- a/src/main/java/use_cases/turn_start_use_case/TurnStartOutputBoundary.java
+++ b/src/main/java/use_cases/turn_start_use_case/TurnStartOutputBoundary.java
@@ -1,6 +1,14 @@
 package use_cases.turn_start_use_case;
 
+/**
+ * TurnStartOutputBoundary provides the interface for the presenter to receive
+ * data from the TurnStartInteractor and to update the UI.
+ */
 public interface TurnStartOutputBoundary {
 
-    TurnStartResponseModel updateScreen(TurnStartResponseModel outputData);
+    DrawCardOutputModel showDrawResult(DrawCardOutputModel outputData);
+
+    CreatureStatsUpdateModel showClearBuffs(CreatureStatsUpdateModel outputData);
+
+    TriggerEffectUpdateModel showEffectUpdates(TriggerEffectUpdateModel outputData);
 }

--- a/src/main/java/use_cases/turn_start_use_case/TurnStartOutputBoundary.java
+++ b/src/main/java/use_cases/turn_start_use_case/TurnStartOutputBoundary.java
@@ -1,0 +1,6 @@
+package use_cases.turn_start_use_case;
+
+public interface TurnStartOutputBoundary {
+
+    TurnStartResponseModel updateScreen(TurnStartResponseModel outputData);
+}

--- a/src/main/java/use_cases/turn_start_use_case/TurnStartResponseModel.java
+++ b/src/main/java/use_cases/turn_start_use_case/TurnStartResponseModel.java
@@ -1,0 +1,93 @@
+package use_cases.turn_start_use_case;
+
+import java.util.ArrayList;
+import java.util.List;
+public class TurnStartResponseModel {
+
+    private List<Integer> handIds1;
+    private List<Integer> handIds2;
+    private List<Integer> creatureIds1;
+    private List<Integer> creatureIds2;
+    private List<Integer> hitPoints1;
+    private List<Integer> hitPoints2;
+    private List<Integer> attacks1;
+    private List<Integer> attacks2;
+
+    public TurnStartResponseModel(List<Integer> handIds1, List<Integer> handIds2,
+                                  List<Integer> creatureIds1, List<Integer> creatureIds2,
+                                  List<Integer> hitPoints1, List<Integer> hitPoints2,
+                                  List<Integer> attacks1, List<Integer> attacks2) {
+        this.handIds1 = handIds1;
+        this.handIds2 = handIds2;
+        this.creatureIds1 = creatureIds1;
+        this.creatureIds2 = creatureIds2;
+        this.hitPoints1 = hitPoints1;
+        this.hitPoints2 = hitPoints2;
+        this.attacks1 = attacks1;
+        this.attacks2 = attacks2;
+    }
+
+    public List<Integer> getHandIds1() {
+        return handIds1;
+    }
+
+    public void setHandIds1(List<Integer> handIds1) {
+        this.handIds1 = handIds1;
+    }
+
+    public List<Integer> getHandIds2() {
+        return handIds2;
+    }
+
+    public void setHandIds2(List<Integer> handIds2) {
+        this.handIds2 = handIds2;
+    }
+
+    public List<Integer> getCreatureIds1() {
+        return creatureIds1;
+    }
+
+    public void setCreatureIds1(List<Integer> creatureIds1) {
+        this.creatureIds1 = creatureIds1;
+    }
+
+    public List<Integer> getCreatureIds2() {
+        return creatureIds2;
+    }
+
+    public void setCreatureIds2(List<Integer> creatureIds2) {
+        this.creatureIds2 = creatureIds2;
+    }
+
+    public List<Integer> getHitPoints1() {
+        return hitPoints1;
+    }
+
+    public void setHitPoints1(List<Integer> hitPoints1) {
+        this.hitPoints1 = hitPoints1;
+    }
+
+    public List<Integer> getHitPoints2() {
+        return hitPoints2;
+    }
+
+    public void setHitPoints2(List<Integer> hitPoints2) {
+        this.hitPoints2 = hitPoints2;
+    }
+
+    public List<Integer> getAttacks1() {
+        return attacks1;
+    }
+
+    public void setAttacks1(List<Integer> attacks1) {
+        this.attacks1 = attacks1;
+    }
+
+    public List<Integer> getAttacks2() {
+        return attacks2;
+    }
+
+    public void setAttacks2(List<Integer> attacks2) {
+        this.attacks2 = attacks2;
+    }
+}

--- a/src/main/java/use_cases/turn_start_use_case/TurnStartResponseModel.java
+++ b/src/main/java/use_cases/turn_start_use_case/TurnStartResponseModel.java
@@ -13,6 +13,11 @@ public class TurnStartResponseModel {
     private List<Integer> attacks1;
     private List<Integer> attacks2;
 
+
+    public TurnStartResponseModel(List<Integer> handIds1) {
+        this.handIds1 = handIds1;
+    }
+
     public TurnStartResponseModel(List<Integer> handIds1, List<Integer> handIds2,
                                   List<Integer> creatureIds1, List<Integer> creatureIds2,
                                   List<Integer> hitPoints1, List<Integer> hitPoints2,

--- a/src/test/java/use_cases/turn_start_use_case/TurnStartInteractorTest.java
+++ b/src/test/java/use_cases/turn_start_use_case/TurnStartInteractorTest.java
@@ -1,0 +1,27 @@
+package use_cases.turn_start_use_case;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TurnStartInteractorTest {
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @Test
+    void testDrawCards() {
+
+    }
+
+    @Test
+    void testClearTemporaryEffects() {
+
+    }
+
+    @Test
+    void testTriggerTurnStartEffects() {
+    }
+}

--- a/src/test/java/use_cases/turn_start_use_case/TurnStartInteractorTest.java
+++ b/src/test/java/use_cases/turn_start_use_case/TurnStartInteractorTest.java
@@ -4,10 +4,7 @@ import entities.GameEvent;
 import entities.GameState;
 import entities.Player;
 import entities.PlayerFactory;
-import entities.cardEffects.CardEffect;
-import entities.cardEffects.DamageEffect;
-import entities.cardEffects.DamageModifyEffect;
-import entities.cardEffects.HealEffect;
+import entities.cardEffects.*;
 import entities.cards.*;
 import entities.decks.Deck;
 import entities.decks.DeckFactory;
@@ -221,4 +218,40 @@ class TurnStartInteractorTest {
         TurnStartInteractor interactor = new TurnStartInteractor(gameState, presenter);
         interactor.triggerTurnStartEffects();
     }
+    @Test
+    void testTriggerTurnStartEffects_playerEvent() {
+        List<CardEffect> effects = new ArrayList<>(List.of(new DrawCardEffect(2, "ESSENCE_DECK")));
+        PlayableCardData cardData = new PlayableCardData("desc", TargetType.SELF, effects);
+        StructureCard structure = new StructureCard(100, "struct", cardData, GameEvent.TURN_START);
+        gameState.getCurrentPlayer().setStructure(structure);
+
+        TurnStartOutputBoundary presenter = new TurnStartOutputBoundary() {
+            @Override
+            public DrawCardOutputModel showDrawResult(DrawCardOutputModel outputData) {
+                fail("triggerTurnStartEffects() should not call showDrawResult().");
+                return null;
+            }
+
+            @Override
+            public CreatureStatsUpdateModel showClearBuffs(CreatureStatsUpdateModel outputData) {
+                fail("triggerTurnStartEffects() should not call showClearBuffs().");
+                return null;
+            }
+
+            @Override
+            public TriggerEffectUpdateModel showEffectUpdates(TriggerEffectUpdateModel outputData) {
+                CreatureStatsUpdateModel creatureStats = outputData.getAllCreatureStats();
+                assertEquals(List.of(1), creatureStats.getHitPoints1());
+                assertEquals(List.of(1), creatureStats.getHitPoints2());
+                assertEquals(List.of(1), creatureStats.getAttacks1());
+                assertEquals(List.of(1), creatureStats.getAttacks2());
+                assertEquals(List.of(13,14),outputData.getFinalHandIds());
+                return null;
+            }
+        };
+        TurnStartInteractor interactor = new TurnStartInteractor(gameState, presenter);
+        interactor.triggerTurnStartEffects();
+    }
+
 }
+

--- a/src/test/java/use_cases/turn_start_use_case/TurnStartInteractorTest.java
+++ b/src/test/java/use_cases/turn_start_use_case/TurnStartInteractorTest.java
@@ -1,27 +1,93 @@
 package use_cases.turn_start_use_case;
 
+import entities.GameState;
+import entities.Player;
+import entities.PlayerFactory;
+import entities.cardEffects.CardEffect;
+import entities.cardEffects.HealEffect;
+import entities.cards.*;
+import entities.decks.Deck;
+import entities.decks.DeckFactory;
+import entities.decks.EssenceDeck;
+import entities.decks.PlayerDeck;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class TurnStartInteractorTest {
 
+    GameState gameState;
+
     @BeforeEach
     void setUp() {
+        CardFactory cardFactory = new CardFactory();
+        PlayerFactory playerFactory = new PlayerFactory();
+        DeckFactory deckFactory = new DeckFactory();
+
+        List<CardEffect> effects = new ArrayList<>(List.of(new HealEffect(10)));
+        PlayableCardData cardData = new PlayableCardData("Some card", TargetType.ANY, effects);
+        Card card1 = cardFactory.createActionCard("name1", cardData);
+
+        Deck playerDeck1 = deckFactory.createPlayerDeck(new ArrayList<>(List.of(card1, card1, card1)));
+        Deck playerDeck2 = deckFactory.createPlayerDeck(new ArrayList<>(List.of(card1, card1, card1)));
+        Deck essenceDeck1 = deckFactory.createEssenceDeck(cardFactory);
+        Deck essenceDeck2 = deckFactory.createEssenceDeck(cardFactory);
+
+        CreatureCard creature1 = (CreatureCard) cardFactory.createCreatureCard("Name1", 1, 1, 1, 1);
+        CreatureCard creature2 = (CreatureCard) cardFactory.createCreatureCard("Name2", 1, 1, 1, 1);
+
+        Player player1 = playerFactory.createPlayer("Player 1", new ArrayList<>(List.of(creature1)),
+                (PlayerDeck) playerDeck1, (EssenceDeck) essenceDeck1);
+        Player player2 = playerFactory.createPlayer("Player 2", new ArrayList<>(List.of(creature2)),
+                (PlayerDeck) playerDeck2, (EssenceDeck) essenceDeck2);
+
+        gameState = new GameState();
+        gameState.setPlayers(player1, player2);
     }
 
     @Test
     void testDrawCards() {
-
+        TurnStartOutputBoundary presenter = new TurnStartOutputBoundary() {
+            @Override
+            public TurnStartResponseModel updateScreen(TurnStartResponseModel outputData) {
+                assertEquals(4, outputData.getHandIds1().size(),
+                        "Player 1 should have 4 cards.");
+                assertNull(outputData.getHandIds2(),
+                        "Player 2 should not have cards.");
+                assertNull(outputData.getAttacks1(),
+                        "For drawCard(), there shouldn't be any input in the other attributes.");
+                return null;
+            }
+        };
+        TurnStartInteractor interactor = new TurnStartInteractor(gameState, presenter);
+        interactor.drawCards();
     }
 
     @Test
     void testClearTemporaryEffects() {
-
+        // The current player's creatures are given a health buff of 5,
+        // We expect the buff to be cleared when this method is run.
+        Player player = gameState.getCurrentPlayer();
+        for (CreatureCard c : player.getCreatures()) {
+            c.addHealthBuff(5);
+        }
+        TurnStartOutputBoundary presenter = new TurnStartOutputBoundary() {
+            @Override
+            public TurnStartResponseModel updateScreen(TurnStartResponseModel outputData) {
+                assertEquals(List.of(1), outputData.getHitPoints1());
+                return null;
+            }
+        };
+        TurnStartInteractor interactor = new TurnStartInteractor(gameState, presenter);
+        interactor.clearTemporaryEffects();
     }
 
     @Test
     void testTriggerTurnStartEffects() {
+
     }
 }

--- a/src/test/java/use_cases/turn_start_use_case/TurnStartInteractorTest.java
+++ b/src/test/java/use_cases/turn_start_use_case/TurnStartInteractorTest.java
@@ -1,9 +1,12 @@
 package use_cases.turn_start_use_case;
 
+import entities.GameEvent;
 import entities.GameState;
 import entities.Player;
 import entities.PlayerFactory;
 import entities.cardEffects.CardEffect;
+import entities.cardEffects.DamageEffect;
+import entities.cardEffects.DamageModifyEffect;
 import entities.cardEffects.HealEffect;
 import entities.cards.*;
 import entities.decks.Deck;
@@ -32,11 +35,13 @@ class TurnStartInteractorTest {
         PlayableCardData cardData = new PlayableCardData("Some card", TargetType.ANY, effects);
         Card card1 = cardFactory.createActionCard("name1", cardData);
 
+        // Note that card1 should have id 1, so right now all the play deck cards have id 1.
         Deck playerDeck1 = deckFactory.createPlayerDeck(new ArrayList<>(List.of(card1, card1, card1)));
         Deck playerDeck2 = deckFactory.createPlayerDeck(new ArrayList<>(List.of(card1, card1, card1)));
         Deck essenceDeck1 = deckFactory.createEssenceDeck(cardFactory);
         Deck essenceDeck2 = deckFactory.createEssenceDeck(cardFactory);
 
+        // note that creature1 should have id 2, and creature2 has id 3.
         CreatureCard creature1 = (CreatureCard) cardFactory.createCreatureCard("Name1", 1, 1, 1, 1);
         CreatureCard creature2 = (CreatureCard) cardFactory.createCreatureCard("Name2", 1, 1, 1, 1);
 
@@ -45,21 +50,35 @@ class TurnStartInteractorTest {
         Player player2 = playerFactory.createPlayer("Player 2", new ArrayList<>(List.of(creature2)),
                 (PlayerDeck) playerDeck2, (EssenceDeck) essenceDeck2);
 
+        // Leave Player 1 with an empty hand, but give Player 2 a hand of 9 cards.
+        for (int i = 0; i < 9; i++) {
+            player2.addCard(player2.getEssenceDeck().draw());
+        }
         gameState = new GameState();
         gameState.setPlayers(player1, player2);
     }
 
     @Test
-    void testDrawCards() {
+    void testDrawCards_BelowHandCapacity() {
         TurnStartOutputBoundary presenter = new TurnStartOutputBoundary() {
             @Override
-            public TurnStartResponseModel updateScreen(TurnStartResponseModel outputData) {
-                assertEquals(4, outputData.getHandIds1().size(),
-                        "Player 1 should have 4 cards.");
-                assertNull(outputData.getHandIds2(),
-                        "Player 2 should not have cards.");
-                assertNull(outputData.getAttacks1(),
-                        "For drawCard(), there shouldn't be any input in the other attributes.");
+            public DrawCardOutputModel showDrawResult(DrawCardOutputModel outputData) {
+                assertEquals(4, outputData.getNewCardIds().size(),
+                        "2 play deck cards and 2 Essence cards should be drawn.");
+                assertEquals(0, outputData.getBurntCardIds().size(),
+                        "No cards should be discarded because hand is not full.");
+                return null;
+            }
+
+            @Override
+            public CreatureStatsUpdateModel showClearBuffs(CreatureStatsUpdateModel outputData) {
+                fail("drawCards() should not call showClearBuffs().");
+                return null;
+            }
+
+            @Override
+            public TriggerEffectUpdateModel showEffectUpdates(TriggerEffectUpdateModel outputData) {
+                fail("drawCards() should not call showEffectUpdates().");
                 return null;
             }
         };
@@ -68,26 +87,138 @@ class TurnStartInteractorTest {
     }
 
     @Test
-    void testClearTemporaryEffects() {
-        // The current player's creatures are given a health buff of 5,
+    void testDrawCards_ExceedHandCapacity() {
+        TurnStartOutputBoundary presenter = new TurnStartOutputBoundary() {
+            @Override
+            public DrawCardOutputModel showDrawResult(DrawCardOutputModel outputData) {
+                assertEquals(1, outputData.getNewCardIds().size(),
+                        "1 play deck card should be drawn.");
+                assertEquals(1, outputData.getNewCardIds().size(),
+                        "The card drawn should have id 1, which comes from the PlayerDeck, not EssenceDeck.");
+                assertTrue(outputData.getNewCardNames().contains("name1"),
+                        "The output should contain the name of the card.");
+                assertEquals(3, outputData.getBurntCardIds().size(),
+                        "3 cards should be discarded because hand is full.");
+                assertTrue(outputData.getBurntCardNames().contains("Essence"),
+                        "There should be cards with name 'Essence' in the discarded cards.");
+                return null;
+            }
+
+            @Override
+            public CreatureStatsUpdateModel showClearBuffs(CreatureStatsUpdateModel outputData) {
+                fail("drawCards() should not call showClearBuffs().");
+                return null;
+            }
+
+            @Override
+            public TriggerEffectUpdateModel showEffectUpdates(TriggerEffectUpdateModel outputData) {
+                fail("drawCards() should not call showEffectUpdates().");
+                return null;
+            }
+        };
+        gameState.switchPlayer();  // this test is for Player 2.
+        TurnStartInteractor interactor = new TurnStartInteractor(gameState, presenter);
+        interactor.drawCards();
+    }
+
+    @Test
+    void testClearBuffs() {
+        // The current player's creatures are given a health buff of 100,
         // We expect the buff to be cleared when this method is run.
         Player player = gameState.getCurrentPlayer();
         for (CreatureCard c : player.getCreatures()) {
-            c.addHealthBuff(5);
+            c.addHealthBuff(100);
         }
         TurnStartOutputBoundary presenter = new TurnStartOutputBoundary() {
             @Override
-            public TurnStartResponseModel updateScreen(TurnStartResponseModel outputData) {
-                assertEquals(List.of(1), outputData.getHitPoints1());
+            public DrawCardOutputModel showDrawResult(DrawCardOutputModel outputData) {
+                fail("clearBuff() should not call showDrawResult().");
+                return null;
+            }
+
+            @Override
+            public CreatureStatsUpdateModel showClearBuffs(CreatureStatsUpdateModel outputData) {
+                assertTrue(outputData.getCreatureIds1().contains(2), "Creature id should be 2.");
+                assertTrue(outputData.getAttacks1().contains(1), "Creature attack should remain 1.");
+                assertTrue(outputData.getHitPoints1().contains(1), "Creature hitPoints should be back to 1.");
+                assertTrue(outputData.getCreatureIds2().contains(3), "Player 2 creatures should have the original stats.");
+                assertTrue(outputData.getAttacks2().contains(1), "Player 2 creatures should have the original stats.");
+                assertTrue(outputData.getHitPoints2().contains(1), "Player 2 creatures should have the original stats.");
+                return null;
+            }
+
+            @Override
+            public TriggerEffectUpdateModel showEffectUpdates(TriggerEffectUpdateModel outputData) {
+                fail("clearBuff() should not call showEffectUpdates().");
                 return null;
             }
         };
         TurnStartInteractor interactor = new TurnStartInteractor(gameState, presenter);
-        interactor.clearTemporaryEffects();
+        interactor.clearBuffs();
     }
 
     @Test
-    void testTriggerTurnStartEffects() {
+    void testTriggerTurnStartEffects_correctEvent() {
+        List<CardEffect> effects = new ArrayList<>(List.of(new DamageEffect(10)));
+        PlayableCardData cardData = new PlayableCardData("desc", TargetType.ALL, effects);
+        StructureCard structure = new StructureCard(100, "struct", cardData, GameEvent.TURN_START);
+        gameState.getCurrentPlayer().setStructure(structure);
 
+        TurnStartOutputBoundary presenter = new TurnStartOutputBoundary() {
+            @Override
+            public DrawCardOutputModel showDrawResult(DrawCardOutputModel outputData) {
+                fail("triggerTurnStartEffects() should not call showDrawResult().");
+                return null;
+            }
+
+            @Override
+            public CreatureStatsUpdateModel showClearBuffs(CreatureStatsUpdateModel outputData) {
+                fail("triggerTurnStartEffects() should not call showClearBuffs().");
+                return null;
+            }
+
+            @Override
+            public TriggerEffectUpdateModel showEffectUpdates(TriggerEffectUpdateModel outputData) {
+                CreatureStatsUpdateModel creatureStats = outputData.getAllCreatureStats();
+                assertEquals(List.of(-9), creatureStats.getHitPoints1());
+                assertEquals(List.of(-9), creatureStats.getHitPoints2());
+                return null;
+            }
+        };
+        TurnStartInteractor interactor = new TurnStartInteractor(gameState, presenter);
+        interactor.triggerTurnStartEffects();
+    }
+
+    @Test
+    void testTriggerTurnStartEffects_irrelevantEvent() {
+        List<CardEffect> effects = new ArrayList<>(List.of(new DamageEffect(10)));
+        PlayableCardData cardData = new PlayableCardData("desc", TargetType.ALL, effects);
+        // this one triggers at TURN_END, so it should not be effective here.
+        StructureCard structure = new StructureCard(100, "struct", cardData, GameEvent.TURN_END);
+        gameState.getCurrentPlayer().setStructure(structure);
+
+        TurnStartOutputBoundary presenter = new TurnStartOutputBoundary() {
+            @Override
+            public DrawCardOutputModel showDrawResult(DrawCardOutputModel outputData) {
+                fail("triggerTurnStartEffects() should not call showDrawResult().");
+                return null;
+            }
+
+            @Override
+            public CreatureStatsUpdateModel showClearBuffs(CreatureStatsUpdateModel outputData) {
+                fail("triggerTurnStartEffects() should not call showClearBuffs().");
+                return null;
+            }
+
+            @Override
+            public TriggerEffectUpdateModel showEffectUpdates(TriggerEffectUpdateModel outputData) {
+                CreatureStatsUpdateModel creatureStats = outputData.getAllCreatureStats();
+                assertEquals(List.of(1), creatureStats.getHitPoints1());
+                assertEquals(List.of(1), creatureStats.getHitPoints2());
+                return null;
+            }
+        };
+        TurnStartInteractor interactor = new TurnStartInteractor(gameState, presenter);
+        interactor.triggerTurnStartEffects();
     }
 }

--- a/src/test/java/use_cases/turn_start_use_case/TurnStartInteractorTest.java
+++ b/src/test/java/use_cases/turn_start_use_case/TurnStartInteractorTest.java
@@ -98,6 +98,8 @@ class TurnStartInteractorTest {
                         "3 cards should be discarded because hand is full.");
                 assertTrue(outputData.getBurntCardNames().contains("Essence"),
                         "There should be cards with name 'Essence' in the discarded cards.");
+                assertTrue(outputData.getBurntCardNames().contains("name1"),
+                        "There should be a card with name 'name1' in the discarded cards.");
                 return null;
             }
 


### PR DESCRIPTION
This feature handles when the game is at the start-of-turn for either of the player. The start-of-turn events are separated into 3 parts and handled individually. 
1) The current player drawing the cards (two from the players deck, then two from the essence deck). 
2)The current player's creatures all temporary effects such as attack buffs being cleared.
3) The start of turn effects being triggered.
